### PR TITLE
Add new fun for KmpPublicStorage

### DIFF
--- a/shared/src/androidMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/androidMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -60,5 +60,32 @@ actual class KmpPublicStorage {
         fun getAllKeys() : List<String>{
             return sharedPreference.all.keys.toList()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            return sharedPreference.getString(key, defValue)
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            return sharedPreference.getInt(key, defValue)
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            return sharedPreference.getLong(key, defValue)
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            return sharedPreference.getFloat(key, defValue)
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            return sharedPreference.getFloat(key, defValue.toFloat()).toDouble()
+        }
+
+        actual fun getBooleanFromKey(
+            key: String,
+            defValue: Boolean
+        ): Boolean {
+            return sharedPreference.getBoolean(key, defValue)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/commonMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -11,11 +11,24 @@ expect class KmpPublicStorage {
         fun deleteDataForKey(key: String)
         fun <TData> persistData(key: String, item: TData)
 
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getStingFromKey(key: String, defValue: String?)"))
         fun getStringFromKey(key: String): String?
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getIntFromKey(key: String, defValue: Int)"))
         fun getIntFromKey(key: String): Int?
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getLongFromKey(key: String, defValue: Long)"))
         fun getLongFromKey(key: String): Long?
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getFloatFromKey(key: String, defValue: Float)"))
         fun getFloatFromKey(key: String): Float?
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getDoubleFromKey(key: String, defValue: Double)"))
         fun getDoubleFromKey(key: String): Double?
+        @Deprecated("Deprecated", replaceWith = ReplaceWith("getBooleanFromKey(key: String, defValue: Boolean)"))
         fun getBooleanFromKey(key: String): Boolean?
+
+        fun getStringFromKey(key: String, defValue: String?): String?
+        fun getIntFromKey(key: String, defValue: Int): Int
+        fun getLongFromKey(key: String, defValue: Long): Long
+        fun getFloatFromKey(key: String, defValue: Float): Float
+        fun getDoubleFromKey(key: String, defValue: Double): Double
+        fun getBooleanFromKey(key: String, defValue: Boolean): Boolean
     }
 }

--- a/shared/src/iosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/iosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -46,6 +46,32 @@ actual class KmpPublicStorage {
             return NSUserDefaults.standardUserDefaults.doubleForKey(key)
         }
 
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            return NSUserDefaults.standardUserDefaults.stringForKey(key) ?: defValue
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Long?)?.toInt() ?: defValue
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Long?) ?: defValue
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Float?) ?: defValue
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Double?) ?: defValue
+        }
+
+        actual fun getBooleanFromKey(
+            key: String,
+            defValue: Boolean
+        ): Boolean {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Boolean?) ?: defValue
+        }
     }
 
 }

--- a/shared/src/jvmMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/jvmMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -37,5 +37,29 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             TODO()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getBooleanFromKey(key: String, defValue: Boolean): Boolean {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/shared/src/linuxMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/linuxMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -37,5 +37,29 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             TODO()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getBooleanFromKey(key: String, defValue: Boolean): Boolean {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/shared/src/macosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/macosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -37,5 +37,29 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             TODO()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getBooleanFromKey(key: String, defValue: Boolean): Boolean {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/shared/src/mingwMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/mingwMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -36,5 +36,29 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             TODO()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getBooleanFromKey(key: String, defValue: Boolean): Boolean {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/shared/src/tvosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/tvosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -36,5 +36,29 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             TODO()
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            TODO("Not yet implemented")
+        }
+
+        actual fun getBooleanFromKey(key: String, defValue: Boolean): Boolean {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/shared/src/watchosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
+++ b/shared/src/watchosMain/kotlin/com/architect/kmpessentials/secureStorage/KmpPublicStorage.kt
@@ -48,5 +48,32 @@ actual class KmpPublicStorage {
         actual fun getDoubleFromKey(key: String): Double? {
             return NSUserDefaults.standardUserDefaults.doubleForKey(key)
         }
+
+        actual fun getStringFromKey(key: String, defValue: String?): String? {
+            return NSUserDefaults.standardUserDefaults.stringForKey(key) ?: defValue
+        }
+
+        actual fun getIntFromKey(key: String, defValue: Int): Int {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Long?)?.toInt() ?: defValue
+        }
+
+        actual fun getLongFromKey(key: String, defValue: Long): Long {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Long?) ?: defValue
+        }
+
+        actual fun getFloatFromKey(key: String, defValue: Float): Float {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Float?) ?: defValue
+        }
+
+        actual fun getDoubleFromKey(key: String, defValue: Double): Double {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Double?) ?: defValue
+        }
+
+        actual fun getBooleanFromKey(
+            key: String,
+            defValue: Boolean
+        ): Boolean {
+            return (NSUserDefaults.standardUserDefaults.objectForKey(key) as Boolean?) ?: defValue
+        }
     }
 }


### PR DESCRIPTION
I made some changes to KmpPublicStorage to improve compatibility. 

In Android, I added a defValue to guarantee the return of a value, similar to Android SharedPreferences. 
In iOS, I added defValue and changed the methods to return objects that are cast to Int, Double, and Float, because in the past, getIntFromKey returned nothing. 

These changes work for me in my app. Please review and test them in your own applications.